### PR TITLE
refactor: useOverlay 훅 로직 제거 및 스타일 수정, 아이콘 lucide로 수정

### DIFF
--- a/apps/web/src/assets/images/FloatingCloseImage.tsx
+++ b/apps/web/src/assets/images/FloatingCloseImage.tsx
@@ -1,15 +1,9 @@
-import Image from 'next/image';
+import { X } from 'lucide-react';
 
 export default function FloatingCloseImage() {
   return (
     <div className="flex justify-center">
-      <Image
-        src={'/icons/floating-close-icon.svg'}
-        alt="플로팅 버튼 닫기 아이콘"
-        width={20}
-        height={20}
-        className="fade-in"
-      />
+      <X className="fade-in w-8 h-8" />
     </div>
   );
 }

--- a/apps/web/src/assets/images/FloatingOpenImage.tsx
+++ b/apps/web/src/assets/images/FloatingOpenImage.tsx
@@ -1,15 +1,9 @@
-import Image from 'next/image';
+import { PenLine } from 'lucide-react';
 
 export default function FloatingOpenImage() {
   return (
     <div className="flex justify-center">
-      <Image
-        src={'/icons/floating-open-icon.svg'}
-        alt="플로팅 버튼 열기 아이콘"
-        width={24}
-        height={24}
-        className="fade-In"
-      />
+      <PenLine className="fade-in" />
     </div>
   );
 }

--- a/apps/web/src/components/buttons/FloatingButton.tsx
+++ b/apps/web/src/components/buttons/FloatingButton.tsx
@@ -6,7 +6,6 @@ import { CATEGORY_LIST } from './constant';
 import { twMerge } from 'tailwind-merge';
 import FloatingOpenIcon from '@/assets/images/FloatingOpenImage';
 import FloatingCloseIcon from '@/assets/images/FloatingCloseImage';
-import { useOverlay } from '@/hooks/ui/useOverlay';
 
 /** * 플로팅 버튼 컴포넌트
  * - AsideButton을 사용하여 카테고리 목록을 표시
@@ -18,7 +17,6 @@ export default function FloatingButton() {
   const [isOpen, setIsOpen] = useState(false); //애니메이션 제어 전용
   const [isMounted, setIsMounted] = useState(false); // 렌더링 제어 전용
   const floatingButtonRef = useRef<HTMLButtonElement>(null); // 포커스 제어용 플로팅 버튼 참조
-  const { openOverlay, closeOverlay } = useOverlay(); // 오버레이 제어 훅
 
   /*  키보드 접근성 관련  */
   // 메뉴 열릴 때 첫 번째 버튼에 포커스
@@ -36,8 +34,7 @@ export default function FloatingButton() {
     const handleEsc = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         setIsOpen(false);
-        floatingButtonRef.current?.focus(); //플로팅 버튼에 포커스 이동동
-        openOverlay(<></>, { backdrop: true }); // 오버레이 열기
+        floatingButtonRef.current?.focus(); //플로팅 버튼에 포커스 이동
       }
     };
 
@@ -95,10 +92,8 @@ export default function FloatingButton() {
     if (!isOpen) {
       setIsMounted(true); // 바로 렌더링
       setIsOpen(true); // fade-in 바로 작동
-      openOverlay(<></>, { backdrop: true }); // 오버레이 열기
     } else {
       setIsOpen(false); // fade-out 클래스 붙이기
-      closeOverlay(); // 오버레이 닫기
     }
   };
 
@@ -142,8 +137,7 @@ export default function FloatingButton() {
         ref={floatingButtonRef}
         className={twMerge(`
           z-3000
-          w-12 h-12 rounded-full text-white shadow-lg border-2 border-soso-600 transition-colors duration-200
-          ${isOpen ? 'bg-soso-600' : 'bg-white text-soso-600 '}
+          w-12 h-12 rounded-full text-white shadow-lg border-2 border-soso-600 transition-colors duration-200 bg-soso-600
         `)}
         onClick={handleFloatingButtonClick}
       >


### PR DESCRIPTION
---
name: '📝 Pull Request'
about: '코드 변경 내용을 쉽게 공유하고 이슈를 자동으로 닫아요'
---

---

# 📌 개요

이번 PR에서 바뀐 내용을 한 줄로 요약해주세요.
- useOverlay 관련 로직을 제거했습니다 (사용 시 플로팅 버튼이 위로 안 뜸)
   -> 추후 수정이 필요
- 변경된 피그마 시안에 맞춰 버튼 스타일을 수정하였습니다
- 아이콘을 기존에 svg로 불러오는 방법에서 lucide 사용하는 방식으로 변경했습니다

---

## 🔗 이슈


---

## 📸 스크린샷

UI 변경이 있을 경우, Before / After 스크린샷을 첨부해주세요.

---

## ✅ 체크리스트

- [] 코드가 스타일 가이드를 따릅니다

- [] 자체 코드 리뷰를 완료했습니다

- [] 복잡/핵심 로직에 주석을 추가했습니다

- [] 관심사 분리를 확인했습니다

- [] 잠재적 사이드이펙트를 점검했습니다

- [] Vercel Preview로 테스트를 완료했습니다

---

## 🧪 테스트 방법

변경 사항을 검증한 방법을 간단히 적어주세요.


---

## 📝 추가 노트

리뷰어에게 알려야 할 부가 정보가 있으면 적어주세요.

