### PR TITLE
Feat/image input

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -55,6 +55,7 @@
   /* 백그라운드 색상 */
   --color-modal: rgba(255, 255, 255, 0.95);
   --color-overlay: rgba(0, 0, 0, 0.6);
+  --color-light-gray: #fafafa;
 
   /* 에러 색상 */
   --color-error-normal: #f44336;

--- a/apps/web/src/components/ImageInput.tsx
+++ b/apps/web/src/components/ImageInput.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+
+interface ImageInputProps {
+  /** 선택된 이미지 파일들을 상위 컴포넌트로 전달 */
+  onFileSelect?: (files: File[]) => void;
+}
+
+/**
+ * ImageInput - 다중 이미지 업로드 컴포넌트
+ *
+ * - 최대 4장까지 이미지 업로드 가능
+ * - 이미지 선택 시 미리보기로 표시됨
+ * - 같은 파일을 다시 선택해도 반응함
+ */
+export function ImageInput({ onFileSelect }: ImageInputProps) {
+  // 선택된 이미지 파일 배열 상태
+  const [images, setImages] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleImageClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  /** 파일이 선택되었을 때 실행되는 핸들러 */
+  const handleFileChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    if (!e.target.files) return;
+
+    // 선택된 파일들을 배열로 변환
+    const files = Array.from(e.target.files);
+    const newImages = [...images, ...files].slice(0, 4);
+    setImages(newImages);
+
+    // 같은 파일을 다시 선택할 수 있도록 input 초기화
+    e.target.value = '';
+
+    onFileSelect?.(newImages);
+  };
+
+  return (
+    <div className="flex items-start gap-2">
+      {/* "이미지 추가" 버튼 (이미지가 4개 미만일 때만 표시) */}
+      {images.length < 4 && (
+        <div
+          onClick={handleImageClick}
+          className="w-[100px] h-[100px] bg-gray-100 rounded-md cursor-pointer flex items-center justify-center"
+        >
+          <span className="text-gray-500 text-sm">이미지 추가</span>
+        </div>
+      )}
+
+      {/* 실제 파일 업로드 input (숨겨짐) */}
+      <input
+        type="file"
+        accept=".png, .jpg, .jpeg, .webp"
+        onChange={handleFileChange}
+        ref={fileInputRef}
+        className="hidden"
+        multiple
+      />
+
+      {/* 미리보기 썸네일 영역 */}
+      <div className="flex gap-2 flex-wrap justify-start">
+        {images
+          .slice()
+          .reverse()
+          .map((file, idx) => {
+            // 브라우저에서 파일 미리보기를 위한 URL 생성
+            const url = URL.createObjectURL(file);
+
+            return (
+              <div key={idx} className="w-24 h-24 relative">
+                <img
+                  src={url}
+                  alt={`미리보기 ${idx + 1}`}
+                  className="w-full h-full object-cover rounded-md"
+                />
+              </div>
+            );
+          })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ImageInput.tsx
+++ b/apps/web/src/components/ImageInput.tsx
@@ -89,15 +89,21 @@ export function ImageInput({ onFileSelect }: ImageInputProps) {
 
   return (
     <div className="flex flex-col items-start gap-2">
-      {/* 이미지 추가 버튼 (4개 미만일 때만 노출) */}
-      {images.length < 4 && (
-        <div
-          onClick={handleImageClick}
-          className="w-20 h-20 bg-light-gray rounded-[10px] cursor-pointer flex items-center justify-center"
-        >
-          <Plus className="w-6 h-6 text-neutral-200" />
-        </div>
-      )}
+      {/* 이미지 추가 버튼 (항상 렌더링, 4장일 때는 disabled 스타일 + 클릭 방지) */}
+      <div
+        onClick={() => {
+          if (images.length >= 4) return;
+          handleImageClick();
+        }}
+        className={`w-20 h-20 rounded-[10px] flex items-center justify-center transition 
+      ${
+        images.length >= 4
+          ? 'bg-gray-100 cursor-not-allowed opacity-50'
+          : 'bg-light-gray hover:bg-gray-200 cursor-pointer'
+      }`}
+      >
+        <Plus className="w-6 h-6 text-neutral-200" />
+      </div>
 
       <input
         type="file"

--- a/apps/web/src/components/ImageInput.tsx
+++ b/apps/web/src/components/ImageInput.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import { useToast } from '@/hooks/ui/useToast';
+import { Plus } from 'lucide-react';
+import React, { useEffect, useRef, useState } from 'react';
 
 interface ImageInputProps {
   /** 선택된 이미지 파일들을 상위 컴포넌트로 전달 */
@@ -15,13 +17,32 @@ interface ImageInputProps {
  * - 같은 파일을 다시 선택해도 반응함
  */
 export function ImageInput({ onFileSelect }: ImageInputProps) {
-  // 선택된 이미지 파일 배열 상태
   const [images, setImages] = useState<File[]>([]);
+  const [previewUrls, setPreviewUrls] = useState<string[]>([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const toast = useToast();
 
   const handleImageClick = () => {
     fileInputRef.current?.click();
   };
+
+  /** 이미지 → 미리보기 URL 생성 후 상태 업데이트 */
+  useEffect(() => {
+    // 기존 URL 메모리 해제
+    previewUrls.forEach((url) => URL.revokeObjectURL(url));
+
+    // 새로운 이미지 파일들에 대한 미리보기 URL 생성
+    const newUrls = images
+      .filter((file): file is File => file instanceof File)
+      .map((file) => URL.createObjectURL(file));
+
+    setPreviewUrls(newUrls);
+
+    // 컴포넌트 언마운트 시 URL 해제
+    return () => {
+      newUrls.forEach((url) => URL.revokeObjectURL(url));
+    };
+  }, [images]);
 
   /** 파일이 선택되었을 때 실행되는 핸들러 */
   const handleFileChange = (
@@ -29,30 +50,51 @@ export function ImageInput({ onFileSelect }: ImageInputProps) {
   ) => {
     if (!e.target.files) return;
 
-    // 선택된 파일들을 배열로 변환
-    const files = Array.from(e.target.files);
+    // 파일 목록 → File[] 로 변환
+    const files = Array.from(e.target.files).filter(
+      (file): file is File => file instanceof File,
+    );
+
+    const allowedTypes = ['image/png', 'image/jpeg', 'image/webp'];
+
+    const allValid = files.every((file) =>
+      allowedTypes.includes(file.type),
+    );
+
+    if (!allValid) {
+      toast('지원하지 않는 파일 형식입니다.', 'error');
+      e.target.value = '';
+      return;
+    }
+
+    const total = images.length + files.length;
+
+    if (total > 4) {
+      toast('이미지는 최대 4장까지만 업로드할 수 있어요.', 'error');
+      e.target.value = '';
+      return;
+    }
+
     const newImages = [...images, ...files].slice(0, 4);
     setImages(newImages);
 
-    // 같은 파일을 다시 선택할 수 있도록 input 초기화
-    e.target.value = '';
-
+    e.target.value = ''; // 같은 파일 다시 선택 가능하게 초기화
     onFileSelect?.(newImages);
   };
 
   return (
     <div className="flex items-start gap-2">
-      {/* "이미지 추가" 버튼 (이미지가 4개 미만일 때만 표시) */}
+      {/* 이미지 추가 버튼 (4개 미만일 때만) */}
       {images.length < 4 && (
         <div
           onClick={handleImageClick}
-          className="w-[100px] h-[100px] bg-gray-100 rounded-md cursor-pointer flex items-center justify-center"
+          className="w-20 h-20 bg-light-gray rounded-[10px] cursor-pointer flex items-center justify-center"
         >
-          <span className="text-gray-500 text-sm">이미지 추가</span>
+          <Plus className="w-6 h-6 text-neutral-200" />
         </div>
       )}
 
-      {/* 실제 파일 업로드 input (숨겨짐) */}
+      {/* 실제 파일 input (숨김) */}
       <input
         type="file"
         accept=".png, .jpg, .jpeg, .webp"
@@ -62,25 +104,23 @@ export function ImageInput({ onFileSelect }: ImageInputProps) {
         multiple
       />
 
-      {/* 미리보기 썸네일 영역 */}
+      {/* 미리보기 영역 */}
       <div className="flex gap-2 flex-wrap justify-start">
-        {images
+        {previewUrls
           .slice()
           .reverse()
-          .map((file, idx) => {
-            // 브라우저에서 파일 미리보기를 위한 URL 생성
-            const url = URL.createObjectURL(file);
-
-            return (
-              <div key={idx} className="w-24 h-24 relative">
-                <img
-                  src={url}
-                  alt={`미리보기 ${idx + 1}`}
-                  className="w-full h-full object-cover rounded-md"
-                />
-              </div>
-            );
-          })}
+          .map((url, idx) => (
+            <div
+              key={idx}
+              className="w-20 h-20 rounded-[10px] relative"
+            >
+              <img
+                src={url}
+                alt={`미리보기 ${idx + 1}`}
+                className="w-full h-full object-cover rounded-md"
+              />
+            </div>
+          ))}
       </div>
     </div>
   );

--- a/apps/web/src/components/ImageInput.tsx
+++ b/apps/web/src/components/ImageInput.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useToast } from '@/hooks/ui/useToast';
-import { Plus } from 'lucide-react';
+import { Plus, X } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 
 interface ImageInputProps {
@@ -37,11 +37,6 @@ export function ImageInput({ onFileSelect }: ImageInputProps) {
       .map((file) => URL.createObjectURL(file));
 
     setPreviewUrls(newUrls);
-
-    // 컴포넌트 언마운트 시 URL 해제
-    return () => {
-      newUrls.forEach((url) => URL.revokeObjectURL(url));
-    };
   }, [images]);
 
   /** 파일이 선택되었을 때 실행되는 핸들러 */
@@ -82,6 +77,20 @@ export function ImageInput({ onFileSelect }: ImageInputProps) {
     onFileSelect?.(newImages);
   };
 
+  /** 이미지 제거 핸들러 */
+  const handleFileRemove = (index: number) => {
+    const newImages = [...images];
+    newImages.splice(images.length - 1 - index, 1); // reverse 상태 고려
+
+    const removedUrl = previewUrls[index];
+    if (removedUrl) {
+      URL.revokeObjectURL(removedUrl);
+    }
+
+    setImages(newImages);
+    onFileSelect?.(newImages);
+  };
+
   return (
     <div className="flex items-start gap-2">
       {/* 이미지 추가 버튼 (4개 미만일 때만) */}
@@ -119,6 +128,13 @@ export function ImageInput({ onFileSelect }: ImageInputProps) {
                 alt={`미리보기 ${idx + 1}`}
                 className="w-full h-full object-cover rounded-md"
               />
+              <button
+                type="button"
+                className="absolute -top-1 -right-1 bg-black bg-opacity-50 rounded-full p-1 text-white hover:bg-opacity-70 cursor-pointer"
+                onClick={() => handleFileRemove(idx)}
+              >
+                <X size={12} />
+              </button>
             </div>
           ))}
       </div>

--- a/apps/web/src/components/ImageInput.tsx
+++ b/apps/web/src/components/ImageInput.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { useToast } from '@/hooks/ui/useToast';
-import { Plus, X } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
+import { Plus, X } from 'lucide-react';
+import { useToast } from '@/hooks/ui/useToast';
 
 interface ImageInputProps {
-  /** 선택된 이미지 파일들을 상위 컴포넌트로 전달 */
   onFileSelect?: (files: File[]) => void;
 }
 
@@ -13,8 +12,8 @@ interface ImageInputProps {
  * ImageInput - 다중 이미지 업로드 컴포넌트
  *
  * - 최대 4장까지 이미지 업로드 가능
- * - 이미지 선택 시 미리보기로 표시됨
- * - 같은 파일을 다시 선택해도 반응함
+ * - 이미지 선택 시 미리보기로 표시
+ * - 같은 파일 다시 선택해도 반응
  */
 export function ImageInput({ onFileSelect }: ImageInputProps) {
   const [images, setImages] = useState<File[]>([]);
@@ -22,16 +21,10 @@ export function ImageInput({ onFileSelect }: ImageInputProps) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const toast = useToast();
 
-  const handleImageClick = () => {
-    fileInputRef.current?.click();
-  };
-
-  /** 이미지 → 미리보기 URL 생성 후 상태 업데이트 */
+  // 이미지 → 미리보기 URL 생성
   useEffect(() => {
-    // 기존 URL 메모리 해제
     previewUrls.forEach((url) => URL.revokeObjectURL(url));
 
-    // 새로운 이미지 파일들에 대한 미리보기 URL 생성
     const newUrls = images
       .filter((file): file is File => file instanceof File)
       .map((file) => URL.createObjectURL(file));
@@ -39,19 +32,25 @@ export function ImageInput({ onFileSelect }: ImageInputProps) {
     setPreviewUrls(newUrls);
   }, [images]);
 
-  /** 파일이 선택되었을 때 실행되는 핸들러 */
+  const handleImageClick = () => {
+    fileInputRef.current?.click();
+  };
+
   const handleFileChange = (
     e: React.ChangeEvent<HTMLInputElement>,
   ) => {
     if (!e.target.files) return;
 
-    // 파일 목록 → File[] 로 변환
     const files = Array.from(e.target.files).filter(
       (file): file is File => file instanceof File,
     );
 
-    const allowedTypes = ['image/png', 'image/jpeg', 'image/webp'];
-
+    const allowedTypes = [
+      'image/png',
+      'image/jpeg',
+      'image/webp',
+      'image/gif',
+    ];
     const allValid = files.every((file) =>
       allowedTypes.includes(file.type),
     );
@@ -63,7 +62,6 @@ export function ImageInput({ onFileSelect }: ImageInputProps) {
     }
 
     const total = images.length + files.length;
-
     if (total > 4) {
       toast('이미지는 최대 4장까지만 업로드할 수 있어요.', 'error');
       e.target.value = '';
@@ -72,15 +70,13 @@ export function ImageInput({ onFileSelect }: ImageInputProps) {
 
     const newImages = [...images, ...files].slice(0, 4);
     setImages(newImages);
-
-    e.target.value = ''; // 같은 파일 다시 선택 가능하게 초기화
     onFileSelect?.(newImages);
+    e.target.value = ''; // 같은 파일 다시 선택 가능하도록 초기화
   };
 
-  /** 이미지 제거 핸들러 */
   const handleFileRemove = (index: number) => {
     const newImages = [...images];
-    newImages.splice(images.length - 1 - index, 1); // reverse 상태 고려
+    newImages.splice(images.length - 1 - index, 1); // reverse된 index 고려
 
     const removedUrl = previewUrls[index];
     if (removedUrl) {
@@ -92,8 +88,8 @@ export function ImageInput({ onFileSelect }: ImageInputProps) {
   };
 
   return (
-    <div className="flex items-start gap-2">
-      {/* 이미지 추가 버튼 (4개 미만일 때만) */}
+    <div className="flex flex-col items-start gap-2">
+      {/* 이미지 추가 버튼 (4개 미만일 때만 노출) */}
       {images.length < 4 && (
         <div
           onClick={handleImageClick}
@@ -103,18 +99,17 @@ export function ImageInput({ onFileSelect }: ImageInputProps) {
         </div>
       )}
 
-      {/* 실제 파일 input (숨김) */}
       <input
         type="file"
-        accept=".png, .jpg, .jpeg, .webp"
+        accept=".png, .jpg, .jpeg, .webp, .gif"
         onChange={handleFileChange}
         ref={fileInputRef}
         className="hidden"
         multiple
       />
 
-      {/* 미리보기 영역 */}
-      <div className="flex gap-2 flex-wrap justify-start">
+      {/* 미리보기 이미지 영역 */}
+      <div className="flex gap-2 flex-wrap justify-start items-start">
         {previewUrls
           .slice()
           .reverse()
@@ -130,8 +125,8 @@ export function ImageInput({ onFileSelect }: ImageInputProps) {
               />
               <button
                 type="button"
-                className="absolute -top-1 -right-1 bg-black bg-opacity-50 rounded-full p-1 text-white hover:bg-opacity-70 cursor-pointer"
                 onClick={() => handleFileRemove(idx)}
+                className="absolute -top-1 -right-1 bg-black bg-opacity-50 rounded-full p-1 text-white hover:bg-opacity-70 cursor-pointer"
               >
                 <X size={12} />
               </button>


### PR DESCRIPTION
---
name: '📝 Pull Request'
about: '이미지 인풋 구현'
---
추후 UI 수정 예정

### 📌 개요
- 다중 이미지 업로드 컴포넌트 `ImageInput` 추가  
- 최대 4장까지 업로드 가능, 미리보기 및 삭제/재선택 기능 제공
- 확장자 제한

### 🔗 이슈


### 📸 스크린샷

| Before | After |
|--------|-------|
| (없음) | (스크린샷 첨부 예정) |

### ✅ 체크리스트
- [x] 코드가 스타일 가이드(Prettier, ESLint)를 따릅니다  
- [x] 자체 코드 리뷰를 완료했습니다  
- [x] 중요 로직에 주석을 추가했습니다  
- [ ] 관심사 분리를 확인했습니다  
- [ ] 잠재적 사이드이펙트를 점검했습니다  
- [ ] Vercel Preview에서 정상 동작을 확인했습니다  

### 🧪 테스트 방법
- 최대 4장 업로드 제한 동작 확인

- 4장 초과 업로드 시 toast 에러 메시지 확인

- 허용된 파일 형식만 업로드 가능한지 확인 (png, jpg, jpeg, webp, gif)

- 같은 파일 재선택 가능 여부 확인

- 이미지 삭제 시 순서 자연스럽게 유지되는지 확인

### 📚 사용법 예제

```
import { ImageInput } from '@/components/ImageInput';

export default function MyFormPage() {
  const handleSelect = (files: File[]) => {
    console.log('선택된 이미지 파일들:', files);
    // 예: FormData.append('images', files) 등으로 사용 가능
  };

  return (
    <div>
      <h2 className="text-lg font-semibold mb-2">이미지 업로드</h2>
      <ImageInput onFileSelect={handleSelect} />
    </div>
  );
}
```
onFileSelect 콜백을 통해 선택된 이미지 파일 배열이 상위 컴포넌트로 전달됩니다.

📝 추가 노트

- 추후 UI 수정 필요
- 접근성 향상 필요
- 
