### PR TITLE
refactor /image input, postid page 

### DIFF
--- a/apps/web/src/app/main/community/[tab]/[postid]/components/UserProfile.tsx
+++ b/apps/web/src/app/main/community/[tab]/[postid]/components/UserProfile.tsx
@@ -1,0 +1,55 @@
+// components/UserProfile.tsx
+'use client';
+
+import { Home, Sprout } from 'lucide-react';
+import Image from 'next/image';
+import { relativeTime } from '@/utils/relativeTime';
+
+export interface UserProfileProps {
+  nickname: string;
+  profileImageUrl: string;
+  userType: 'founder' | 'resident';
+  location: string;
+  createdAt: string;
+}
+
+export default function UserProfile({
+  nickname,
+  profileImageUrl,
+  userType,
+  location,
+  createdAt,
+}: UserProfileProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <Image
+        src={profileImageUrl}
+        alt="유저 프로필 이미지"
+        className="w-[45px] h-[45px] rounded-full overflow-hidden bg-neutral-50 p-1"
+        width={45}
+        height={45}
+      />
+      <div>
+        <div className="flex items-center gap-2">
+          <h2 className="text-body font-bold">{nickname}</h2>
+          <div className="text-[8px] px-1 py-0.5 rounded-full text-white bg-soso-600 flex gap-0.5 items-center">
+            {userType === 'founder' ? (
+              <>
+                창업자
+                <Sprout className="w-2 h-2" />
+              </>
+            ) : (
+              <>
+                주민
+                <Home className="w-2 h-2" />
+              </>
+            )}
+          </div>
+        </div>
+        <p className="text-sm text-neutral-500">
+          {location} · {relativeTime(createdAt)}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/main/community/[tab]/[postid]/page.tsx
+++ b/apps/web/src/app/main/community/[tab]/[postid]/page.tsx
@@ -1,9 +1,8 @@
-import { Eye, Home, Sprout } from 'lucide-react';
-import Image from 'next/image';
+import { Eye } from 'lucide-react';
 import type { GetPostResponse } from '@/api/posts';
-import { relativeTime } from '@/utils/relativeTime';
 import LikeButton from '@/app/main/community/[tab]/[postid]/components/LikeButton';
 import ImageSlider from '@/components/ImageSlider';
+import UserProfile from './components/UserProfile';
 
 const dummyPost: GetPostResponse = {
   postId: 1,
@@ -52,41 +51,13 @@ export default function PostPage() {
           </span>
 
           {/* 유저 프로필 */}
-          <div className="flex items-center gap-2">
-            <Image
-              src={post.user.profileImageUrl}
-              alt="유저 프로필 이미지"
-              className="w-[45px] h-[45px] rounded-full overflow-hidden bg-neutral-50 p-1"
-              width={45}
-              height={45}
-            />
-            <div>
-              {/* 닉네임 + 유저타입 뱃지 */}
-              <div className="flex items-center gap-2">
-                <h2 className="text-body font-bold">
-                  {post.user.nickname}
-                </h2>
-                <div className="text-[8px] px-1 py-0.5 rounded-full text-white bg-soso-600 flex gap-0.5 items-center">
-                  {post.user.userType === 'founder' ? (
-                    <>
-                      창업자
-                      <Sprout className="w-2 h-2" />
-                    </>
-                  ) : (
-                    <>
-                      주민
-                      <Home className="w-2 h-2" />
-                    </>
-                  )}
-                </div>
-              </div>
-
-              {/* 위치 + 작성 시간 */}
-              <p className="text-sm text-neutral-500">
-                {post.user.location} · {relativeTime(post.createdAt)}
-              </p>
-            </div>
-          </div>
+          <UserProfile
+            nickname={post.user.nickname}
+            profileImageUrl={post.user.profileImageUrl}
+            userType={post.user.userType as 'founder' | 'resident'}
+            location={post.user.location}
+            createdAt={post.createdAt}
+          />
         </div>
 
         {/* 본문 */}

--- a/apps/web/src/components/ImageInput.tsx
+++ b/apps/web/src/components/ImageInput.tsx
@@ -23,13 +23,18 @@ export function ImageInput({ onFileSelect }: ImageInputProps) {
 
   // 이미지 → 미리보기 URL 생성
   useEffect(() => {
-    previewUrls.forEach((url) => URL.revokeObjectURL(url));
-
+    // 1) images 배열에 따라 새로 Object URL 생성
     const newUrls = images
       .filter((file): file is File => file instanceof File)
       .map((file) => URL.createObjectURL(file));
 
+    // 2) 화면에 보여줄 URL 상태 업데이트
     setPreviewUrls(newUrls);
+
+    // 3) cleanup: images가 바뀌거나 언마운트될 때 이전 newUrls를 모두 해제
+    return () => {
+      newUrls.forEach((url) => URL.revokeObjectURL(url));
+    };
   }, [images]);
 
   const handleImageClick = () => {

--- a/apps/web/src/components/ImageInput.tsx
+++ b/apps/web/src/components/ImageInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { Plus, X } from 'lucide-react';
 import { useToast } from '@/hooks/ui/useToast';
 
@@ -8,6 +8,11 @@ interface ImageInputProps {
   onFileSelect?: (files: File[]) => void;
 }
 
+interface ImageItem {
+  file: File;
+  preview: string;
+  id: string;
+}
 /**
  * ImageInput - 다중 이미지 업로드 컴포넌트
  *
@@ -16,26 +21,9 @@ interface ImageInputProps {
  * - 같은 파일 다시 선택해도 반응
  */
 export function ImageInput({ onFileSelect }: ImageInputProps) {
-  const [images, setImages] = useState<File[]>([]);
-  const [previewUrls, setPreviewUrls] = useState<string[]>([]);
+  const [images, setImages] = useState<ImageItem[]>([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const toast = useToast();
-
-  // 이미지 → 미리보기 URL 생성
-  useEffect(() => {
-    // 1) images 배열에 따라 새로 Object URL 생성
-    const newUrls = images
-      .filter((file): file is File => file instanceof File)
-      .map((file) => URL.createObjectURL(file));
-
-    // 2) 화면에 보여줄 URL 상태 업데이트
-    setPreviewUrls(newUrls);
-
-    // 3) cleanup: images가 바뀌거나 언마운트될 때 이전 newUrls를 모두 해제
-    return () => {
-      newUrls.forEach((url) => URL.revokeObjectURL(url));
-    };
-  }, [images]);
 
   const handleImageClick = () => {
     fileInputRef.current?.click();
@@ -73,23 +61,29 @@ export function ImageInput({ onFileSelect }: ImageInputProps) {
       return;
     }
 
-    const newImages = [...images, ...files].slice(0, 4);
-    setImages(newImages);
-    onFileSelect?.(newImages);
-    e.target.value = ''; // 같은 파일 다시 선택 가능하도록 초기화
+    // File -> ImageItem으로 매핑
+    const items = files.map((file) => ({
+      file,
+      preview: URL.createObjectURL(file), // 미리보기 URL 생성
+      id: crypto.randomUUID(), // 고유 ID 생성
+    }));
+
+    // 최대 4장 제한 + onFileSelect에 File[]만 전달
+    setImages((prev) => {
+      const merged = [...prev, ...items].slice(0, 4);
+      onFileSelect?.(merged.map((item) => item.file));
+      return merged;
+    });
+
+    e.target.value = ''; // 같은 파일 다시 선택 가능
   };
 
-  const handleFileRemove = (index: number) => {
-    const newImages = [...images];
-    newImages.splice(images.length - 1 - index, 1); // reverse된 index 고려
-
-    const removedUrl = previewUrls[index];
-    if (removedUrl) {
-      URL.revokeObjectURL(removedUrl);
-    }
-
-    setImages(newImages);
-    onFileSelect?.(newImages);
+  const handleFileRemove = (removeId: string) => {
+    setImages((prev) => {
+      const filtered = prev.filter((item) => item.id !== removeId);
+      onFileSelect?.(filtered.map((item) => item.file));
+      return filtered;
+    });
   };
 
   return (
@@ -121,22 +115,22 @@ export function ImageInput({ onFileSelect }: ImageInputProps) {
 
       {/* 미리보기 이미지 영역 */}
       <div className="flex gap-2 flex-wrap justify-start items-start">
-        {previewUrls
+        {images
           .slice()
           .reverse()
-          .map((url, idx) => (
+          .map((item) => (
             <div
-              key={idx}
+              key={item.id}
               className="w-20 h-20 rounded-[10px] relative"
             >
               <img
-                src={url}
-                alt={`미리보기 ${idx + 1}`}
+                src={item.preview}
+                alt={`미리보기`}
                 className="w-full h-full object-cover rounded-md"
               />
               <button
                 type="button"
-                onClick={() => handleFileRemove(idx)}
+                onClick={() => handleFileRemove(item.id)}
                 className="absolute -top-1 -right-1 bg-black bg-opacity-50 rounded-full p-1 text-white hover:bg-opacity-70 cursor-pointer"
               >
                 <X size={12} />

--- a/apps/web/src/components/ImageSlider.tsx
+++ b/apps/web/src/components/ImageSlider.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import 'keen-slider/keen-slider.min.css';
-import { useKeenSlider } from 'keen-slider/react';
+import {
+  useKeenSlider,
+  type KeenSliderInstance,
+} from 'keen-slider/react';
 import Image from 'next/image';
 import { twMerge } from 'tailwind-merge';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 /**
  * ImageSliderProps - 이미지 슬라이더 컴포넌트의 props
@@ -37,20 +40,26 @@ export default function ImageSlider({
     })),
   );
 
-  const [sliderRef, instanceRef] = useKeenSlider<HTMLDivElement>({
-    loop: true,
-    drag: true,
-    slides: {
-      perView: 1,
-      spacing: 8,
-    },
-    created() {
-      setLoaded(true);
-    },
-    slideChanged(slider) {
-      setCurrentSlide(slider.track.details.rel);
-    },
-  });
+  const sliderOptions = useMemo(
+    () => ({
+      loop: true,
+      drag: true,
+      slides: {
+        perView: 1,
+        spacing: 8,
+      },
+      created() {
+        setLoaded(true);
+      },
+      slideChanged(slider: KeenSliderInstance) {
+        setCurrentSlide(slider.track.details.rel);
+      },
+    }),
+    [],
+  );
+
+  const [sliderRef, instanceRef] =
+    useKeenSlider<HTMLDivElement>(sliderOptions);
 
   const goToSlide = (index: number) => {
     instanceRef.current?.moveToIdx(index);

--- a/apps/web/src/components/ImageSlider.tsx
+++ b/apps/web/src/components/ImageSlider.tsx
@@ -16,21 +16,26 @@ interface ImageSliderProps {
   className?: string;
 }
 
-/**
- * ImageSlider - 이미지 슬라이더 컴포넌트
- *
- * KeenSlider를 기반으로 한 반응형 이미지 슬라이더
- * 로딩 시 skeleton을 표시 및 페이지네이션 버튼으로 슬라이드 이동이 가능
- *
- * @param {ImageSliderProps} props
- * @returns {JSX.Element}
- */
+// url과 UUID를 함께 담는 타입 정의
+interface SliderImage {
+  url: string;
+  id: string;
+}
+
 export default function ImageSlider({
   images,
   className,
 }: ImageSliderProps) {
   const [currentSlide, setCurrentSlide] = useState(0);
   const [loaded, setLoaded] = useState(false);
+
+  // images prop을 한 번만 매핑해서 id 부여
+  const [sliderImages] = useState<SliderImage[]>(() =>
+    images.map((url) => ({
+      url,
+      id: crypto.randomUUID(),
+    })),
+  );
 
   const [sliderRef, instanceRef] = useKeenSlider<HTMLDivElement>({
     loop: true,
@@ -47,10 +52,6 @@ export default function ImageSlider({
     },
   });
 
-  /**
-   * goToSlide - 페이지네이션 버튼 클릭 시 해당 슬라이드로 이동
-   * @param {number} index - 이동할 슬라이드 인덱스
-   */
   const goToSlide = (index: number) => {
     instanceRef.current?.moveToIdx(index);
   };
@@ -75,14 +76,14 @@ export default function ImageSlider({
             : 'opacity-100 scale-100 translate-y-0',
         )}
       >
-        {images.map((url, index) => (
+        {sliderImages.map((img) => (
           <div
-            key={index}
+            key={img.id}
             className="keen-slider__slide relative h-[200px] md:h-[300px]"
           >
             <Image
-              src={url}
-              alt={`슬라이드 이미지 ${index + 1}`}
+              src={img.url}
+              alt="슬라이드 이미지"
               fill
               sizes="(max-width: 768px) 100vw, 600px"
               className="w-full h-[200px] object-cover"
@@ -93,14 +94,14 @@ export default function ImageSlider({
 
       {/* 페이지네이션 */}
       <div className="flex justify-center gap-2 mt-[12px] min-h-[12px] transition-opacity duration-500">
-        {images.length > 1 &&
-          images.map((_, index) => (
+        {sliderImages.length > 1 &&
+          sliderImages.map((_, idx) => (
             <button
-              key={index}
-              onClick={() => goToSlide(index)}
+              key={sliderImages[idx].id}
+              onClick={() => goToSlide(idx)}
               className={twMerge(
                 'w-1.5 h-1.5 rounded-full bg-neutral-300 transition-all duration-300',
-                currentSlide === index && 'bg-soso-600',
+                currentSlide === idx && 'bg-soso-600',
                 !loaded
                   ? 'opacity-0 pointer-events-none scale-75'
                   : 'opacity-100 scale-100',


### PR DESCRIPTION
---
name: '📝 Pull Request'
about: 'ImageInput, postid page 피드백 반영'
---

---

# 📌 개요

1. ImageInput 컴포넌트 개선
   - 기존: 미리보기 목록을 File[]와 previewUrls: string[]로 각각 관리, key에 index 사용
   - 변경: File, preview URL, UUID(id)를 하나의 타입(ImageItem)으로 통합 관리
   - key: index → crypto.randomUUID() 기반 고유 ID로 변경

2. ImageSlider 컴포넌트 개선
   - 기존: 슬라이드 및 페이지네이션 버튼에 index를 key로 사용
   - 변경: props로 받은 URL 배열을 SliderImage[]({url,id})로 한 번만 매핑
   - key: index → SliderImage.id(UUID)로 변경

3. useKeenSlider 옵션 최적화
   - 기존: useKeenSlider 호출 시 옵션 객체를 매 렌더마다 인라인으로 생성
   - 변경: useMemo를 사용해 옵션 객체를 빈 deps 배열로 메모이제이션, 최초 렌더 시 1회만 생성
   - 효과: 슬라이더 인스턴스 불필요 재생성 방지, 퍼포먼스 개선

4. UserProfile 컴포넌트 분리
   - 기존: PostPage 내에서 아바타·닉네임·뱃지·메타(위치·시간)를 모두 직접 렌더링
   - 변경: 프로필 UI(아바타·닉네임·뱃지)만 담당하는 UserProfile 컴포넌트로 추출
   - 추후 댓글 영역 대응을 위해 variant 또는 children 슬롯 패턴 도입 예정

---

## 🔗 이슈

---

## 📸 스크린샷



---

## ✅ 체크리스트

- [x] 코드가 스타일 가이드를 따릅니다

- [x] 자체 코드 리뷰를 완료했습니다

- [x] 복잡/핵심 로직에 주석을 추가했습니다

- [x] 관심사 분리를 확인했습니다

- [] 잠재적 사이드이펙트를 점검했습니다

- [] Vercel Preview로 테스트를 완료했습니다

---

## 🧪 테스트 방법

변경 사항을 검증한 방법을 간단히 적어주세요.

- [x] ImageInput: 파일 추가/삭제 시 미리보기 정상 출력 및 key 충돌 없음
- [x] ImageSlider: 슬라이드 전환 및 페이지네이션 버튼 정상 동작
- [x] UserProfile: 포스트 페이지에서 정상 렌더 확인

---

## 📝 추가 노트

향후 개선:
- UserProfile: variant prop으로 크기·여백·메타 렌더링 제어 도입

