### PR TITLE
Feat: 자유게시판 리스트 SSR 프리패치 구현 및 스타일 개선

### DIFF
--- a/apps/web/src/app/main/community/components/CommunityPostList.tsx
+++ b/apps/web/src/app/main/community/components/CommunityPostList.tsx
@@ -104,7 +104,7 @@ export default function CommunityPostList<T extends BoardSummary>({
 
       {/* 게시글 목록 */}
       <InfiniteScroll.Contents<T>
-        className={cn('flex flex-col gap-4', className)}
+        className={cn('flex flex-col', className)}
         virtualScroll={{
           enabled: true,
           estimateSize: 156, // 카드 평균 높이

--- a/apps/web/src/app/main/community/components/CommunityPostList.tsx
+++ b/apps/web/src/app/main/community/components/CommunityPostList.tsx
@@ -107,7 +107,7 @@ export default function CommunityPostList<T extends BoardSummary>({
         className={cn('flex flex-col', className)}
         virtualScroll={{
           enabled: true,
-          estimateSize: 156, // 카드 평균 높이
+          estimateSize: 139, // 카드 평균 높이
           overscan: 3,
         }}
         scrollStore={{
@@ -118,7 +118,7 @@ export default function CommunityPostList<T extends BoardSummary>({
         // 안정적인 key 생성을 위한 함수 필수 전달
         getItemKey={getItemKey}
         renderItem={renderItem}
-        gap={16} // 4 * 4px = 16px
+        gap={16}
         threshold={0.8}
       >
         {/* 무한스크롤 트리거 */}

--- a/apps/web/src/app/main/community/components/FreeboardCard.tsx
+++ b/apps/web/src/app/main/community/components/FreeboardCard.tsx
@@ -5,7 +5,7 @@ import { Category } from '../constants/categories';
 import { relativeTime } from '@/utils/relativeTime';
 import { Heart, MessageSquareMore } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-
+import { formatCount } from '@/utils/formatCount';
 import type { FreeboardSummary } from '@/generated/api/models';
 
 export interface FreeBoardCardProps {
@@ -65,7 +65,7 @@ export function FreeBoardCard({
             aria-label={`좋아요 ${likeCount ?? 0}개`}
           >
             <Heart className="w-4 h-4 text-neutral-500" />
-            <span className="text-xs">{likeCount ?? 0}</span>
+            <span className="text-xs">{formatCount(likeCount)}</span>
           </div>
           {/* 댓글 */}
           <div
@@ -73,7 +73,9 @@ export function FreeBoardCard({
             aria-label={`댓글 ${commentCount ?? 0}개`}
           >
             <MessageSquareMore className="w-4 h-4 text-neutral-500" />
-            <span className="text-xs">{commentCount ?? 0}</span>
+            <span className="text-xs">
+              {formatCount(commentCount)}
+            </span>
           </div>
         </div>
       </div>

--- a/apps/web/src/app/main/community/components/FreeboardCard.tsx
+++ b/apps/web/src/app/main/community/components/FreeboardCard.tsx
@@ -1,4 +1,5 @@
 // src/components/CommunityCard.tsx
+import Image from 'next/image';
 import Card from '@/components/Card';
 import { CategoryChip } from '@/components/chips/CategoryChip';
 import { Category } from '../constants/categories';
@@ -20,12 +21,12 @@ export function FreeBoardCard({
   const {
     postId,
     title,
-    contentPreview, // API에서는 contentPreview 사용
+    contentPreview,
     category,
     likeCount,
     commentCount,
     createdAt,
-    author, // API에서는 author 사용
+    author,
   } = post;
 
   const router = useRouter();
@@ -36,23 +37,35 @@ export function FreeBoardCard({
 
   return (
     <Card
-      className="w-full flex flex-col gap-3"
+      className="w-full flex flex-col gap-2"
       onClick={handleOnClick}
     >
-      <div className="flex flex-col gap-1">
-        {isChip && category && (
-          <div className="flex items-center gap-1">
-            <CategoryChip category={category as Category} />
-          </div>
+      {isChip && category && (
+        <div className="flex items-center gap-1">
+          <CategoryChip category={category as Category} />
+        </div>
+      )}
+      <div className="flex flex-row justify-between items-center gap-4">
+        <section className="flex flex-col gap-1">
+          <h3 className="text-title2 truncate" title={title}>
+            {title}
+          </h3>
+          <p className="text-body truncate" title={contentPreview}>
+            {contentPreview}
+          </p>
+        </section>
+        {post.thumbnailUrl && (
+          <Image
+            src={post.thumbnailUrl}
+            alt="게시글 썸네일 이미지"
+            width={55}
+            height={55}
+            className="w-[55px] h-[55px] object-cover rounded-md flex-shrink-0"
+          />
         )}
-        <h3 className="text-title2 truncate" title={title}>
-          {title}
-        </h3>
-        <p className="text-body truncate" title={contentPreview}>
-          {contentPreview}
-        </p>
       </div>
-      <div className="flex justify-between items-center">
+
+      <section className="flex justify-between items-center">
         {/* 작성자 · 시간 */}
         <span className="text-neutral-500 text-xs">
           {author?.nickname ?? '알 수 없음'} ·{' '}
@@ -78,7 +91,7 @@ export function FreeBoardCard({
             </span>
           </div>
         </div>
-      </div>
+      </section>
     </Card>
   );
 }

--- a/apps/web/src/app/main/community/components/SortHeader.tsx
+++ b/apps/web/src/app/main/community/components/SortHeader.tsx
@@ -30,7 +30,7 @@ export function SortHeader({
       )}
       aria-label="정렬 옵션"
     >
-      <p className="text-body2 dark:text-white">
+      <p className="text-body2 text-neutral-800 dark:text-white">
         총 {totalCount}개 게시글
       </p>
 
@@ -39,7 +39,10 @@ export function SortHeader({
         onValueChange={(value) => onFilterChange(value as SortValue)}
         size="sm"
       >
-        <Select.Trigger placeholder="정렬 선택" />
+        <Select.Trigger
+          className="border-none text-neutral-800 dark:text-white justify-end text-sm"
+          placeholder="정렬 선택"
+        />
         <Select.Portal>
           <Select.Content>
             {sortOptions.map((option) => (

--- a/apps/web/src/app/main/community/freeboard/ClientPage.tsx
+++ b/apps/web/src/app/main/community/freeboard/ClientPage.tsx
@@ -80,6 +80,7 @@ export default function FreeboardClientPage() {
         sortOptions={SORT_OPTIONS}
         currentValue={sortOption}
         onFilterChange={setSortOption}
+        className="px-5"
       />
       <CommunityPostList<FreeboardSummary>
         items={allFreeboardPosts}

--- a/apps/web/src/app/main/community/freeboard/ClientPage.tsx
+++ b/apps/web/src/app/main/community/freeboard/ClientPage.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { PillChipsTab } from '@/components/tabs/PillChipsTab';
+import { CATEGORIES, Category } from '../constants/categories';
+import { SortHeader } from '../components/SortHeader';
+import { SortValue } from '@/types/options.types';
+import { SORT_OPTIONS } from '../constants/sortOptions';
+import FloatingButton from '@/components/buttons/FloatingButton';
+import { FreeBoardCard } from '../components/FreeboardCard';
+import CommunityPostList from '../components/CommunityPostList';
+import { FreeboardSummary } from '@/generated/api/models';
+import {
+  getFreeboardPostsByCursor,
+  getGetFreeboardPostsByCursorQueryKey,
+} from '@/generated/api/endpoints/freeboard/freeboard';
+
+/**
+ * 자유 게시판 클라이언트 메인 페이지
+ *
+ * @description
+ * - 카테고리별 게시글 목록을 보여주는 페이지
+ * - 무한스크롤 기능 포함
+ * - 카테고리 및 정렬 옵션 선택 가능
+ */
+
+export default function FreeboardClientPage() {
+  const [category, setCategory] = useState<Category | null>(null);
+  const [sortOption, setSortOption] = useState<SortValue>('LATEST');
+
+  // 무한스크롤 데이터 페칭
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isLoading,
+    isFetchingNextPage,
+    error,
+    refetch,
+  } = useInfiniteQuery({
+    queryKey: getGetFreeboardPostsByCursorQueryKey({
+      // queryKey 생성 함수 사용
+      category: category ?? undefined, // null일 경우 undefined로 변환
+      sort: sortOption,
+    }),
+    queryFn: ({ pageParam, signal }) =>
+      getFreeboardPostsByCursor(
+        {
+          category: category ?? undefined,
+          sort: sortOption,
+          cursor: pageParam,
+          size: 10,
+        },
+        signal,
+      ),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => {
+      return lastPage.hasNext ? lastPage.nextCursor : undefined;
+    },
+  });
+
+  // 모든 페이지의 게시글을 하나의 배열로 합치기
+  const allFreeboardPosts: FreeboardSummary[] =
+    data?.pages.flatMap((page) => page.posts ?? []) ?? [];
+  // 총 게시글 개수
+  const totalCount = data?.pages[0]?.totalCount ?? 0;
+
+  return (
+    <main className="w-full h-full flex flex-col">
+      <PillChipsTab<Category>
+        chips={CATEGORIES}
+        activeValue={category}
+        onChange={setCategory}
+        showAll
+        ariaLabel="카테고리 선택 필터"
+      />
+      <SortHeader
+        totalCount={totalCount}
+        sortOptions={SORT_OPTIONS}
+        currentValue={sortOption}
+        onFilterChange={setSortOption}
+      />
+      <CommunityPostList<FreeboardSummary>
+        items={allFreeboardPosts}
+        hasNextPage={hasNextPage || false}
+        fetchNextPage={fetchNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        initialLoading={isLoading}
+        error={error}
+        onRetry={() => refetch()}
+        getItemKey={(post, index) => post.postId ?? `post-${index}`}
+        renderItem={(post) => (
+          <FreeBoardCard post={post} isChip={true} />
+        )}
+        storageKey="freeboard-post-list-scroll"
+      />
+      <FloatingButton categories={CATEGORIES} />
+    </main>
+  );
+}

--- a/apps/web/src/app/main/community/freeboard/page.tsx
+++ b/apps/web/src/app/main/community/freeboard/page.tsx
@@ -1,101 +1,46 @@
-'use client';
-import React, { useState } from 'react';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { PillChipsTab } from '@/components/tabs/PillChipsTab';
-import { CATEGORIES, Category } from '../constants/categories';
-import { SortHeader } from '../components/SortHeader';
-import { SortValue } from '@/types/options.types';
-import { SORT_OPTIONS } from '../constants/sortOptions';
-import FloatingButton from '@/components/buttons/FloatingButton';
-import { FreeBoardCard } from '../components/FreeboardCard';
-import CommunityPostList from '../components/CommunityPostList';
-
-import { FreeboardSummary } from '@/generated/api/models';
+import {
+  HydrationBoundary,
+  QueryClient,
+  dehydrate,
+} from '@tanstack/react-query';
 import {
   getFreeboardPostsByCursor,
   getGetFreeboardPostsByCursorQueryKey,
 } from '@/generated/api/endpoints/freeboard/freeboard';
+import ClientPage from './ClientPage';
 
 /**
- * 자유 게시판 메인 페이지
+ * 자유 게시판 메인 페이지 (서버 컴포넌트)
  *
  * @description
- * - 카테고리별 게시글 목록을 보여주는 페이지
- * - 무한스크롤 기능 포함
- * - 카테고리 및 정렬 옵션 선택 가능
+ * - 전체 카테고리
+ * - 최신순 정렬
+ * - 10개 게시글 프리패치
  */
 
-export default function FreeboardPage() {
-  const [category, setCategory] = useState<Category | null>(null);
-  const [sortOption, setSortOption] = useState<SortValue>('LATEST');
+export default async function FreeboardPage() {
+  const queryClient = new QueryClient();
 
-  // 무한스크롤 데이터 페칭
-  const {
-    data,
-    fetchNextPage,
-    hasNextPage,
-    isLoading,
-    isFetchingNextPage,
-    error,
-    refetch,
-  } = useInfiniteQuery({
+  await queryClient.prefetchInfiniteQuery({
     queryKey: getGetFreeboardPostsByCursorQueryKey({
-      // queryKey 생성 함수 사용
-      category: category ?? undefined, // null일 경우 undefined로 변환
-      sort: sortOption,
+      category: undefined,
+      sort: 'LATEST',
     }),
-    queryFn: ({ pageParam, signal }) =>
+    queryFn: async ({ signal }) =>
       getFreeboardPostsByCursor(
-        {
-          category: category ?? undefined,
-          sort: sortOption,
-          cursor: pageParam,
-          size: 10,
-        },
+        { category: undefined, sort: 'LATEST', size: 10 },
         signal,
       ),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => {
       return lastPage.hasNext ? lastPage.nextCursor : undefined;
     },
+    pages: 1,
   });
 
-  // 모든 페이지의 게시글을 하나의 배열로 합치기
-  const allFreeboardPosts: FreeboardSummary[] =
-    data?.pages.flatMap((page) => page.posts ?? []) ?? [];
-  // 총 게시글 개수
-  const totalCount = data?.pages[0]?.totalCount ?? 0;
-
   return (
-    <main className="w-full h-full flex flex-col">
-      <PillChipsTab<Category>
-        chips={CATEGORIES}
-        activeValue={category}
-        onChange={setCategory}
-        showAll
-        ariaLabel="카테고리 선택 필터"
-      />
-      <SortHeader
-        totalCount={totalCount}
-        sortOptions={SORT_OPTIONS}
-        currentValue={sortOption}
-        onFilterChange={setSortOption}
-      />
-      <CommunityPostList<FreeboardSummary>
-        items={allFreeboardPosts}
-        hasNextPage={hasNextPage || false}
-        fetchNextPage={fetchNextPage}
-        isFetchingNextPage={isFetchingNextPage}
-        initialLoading={isLoading}
-        error={error}
-        onRetry={() => refetch()}
-        getItemKey={(post, index) => post.postId ?? `post-${index}`}
-        renderItem={(post) => (
-          <FreeBoardCard post={post} isChip={true} />
-        )}
-        storageKey="freeboard-post-list-scroll"
-      />
-      <FloatingButton categories={CATEGORIES} />
-    </main>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ClientPage />
+    </HydrationBoundary>
   );
 }

--- a/apps/web/src/components/tabs/PillChipsTab.tsx
+++ b/apps/web/src/components/tabs/PillChipsTab.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React, { useState, useRef, useMemo } from 'react';
 import { Pressable } from '../Pressable';
 import { twMerge } from 'tailwind-merge';

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -171,6 +171,6 @@ export const config = {
      * - _next/image (이미지 최적화)
      * - favicon.ico (파비콘)
      */
-    '/((?!api|_next/static|_next/image|favicon.ico).*)',
+    '/((?!api|_next/static|_next/image|favicon.ico|\\.well-known).*)',
   ],
 };

--- a/apps/web/src/utils/formatCount.ts
+++ b/apps/web/src/utils/formatCount.ts
@@ -1,16 +1,139 @@
 /**
+ * 포맷 타입
+ * - 'capped': 99+ 형식 (기본값 99)
+ * - 'korean': 1.2만, 100만 형식 (한글 약식)
+ */
+export type FormatType = 'capped' | 'korean';
+
+/**
  * 카운트를 cap 기준으로 단순 표기합니다.
  * - count >= cap  → `${cap}+`
  * - count <  cap  → 로케일 숫자
+ *
+ * @param count - 표시할 숫자
+ * @param options - 옵션
+ * @param options.cap - 임계값 (기본: 99)
+ * @param options.locale - 로케일 (기본: 'ko-KR')
+ * @param options.fallback - count가 invalid일 때 대체값 (기본: '0')
  */
 export function formatCappedCount(
-  count: number,
+  count: number | null | undefined,
   {
-    cap = 99, // 99 이상이면 "99+"
-    locale = 'ko-KR', // 숫자 포맷 로케일
-  }: { cap?: number; locale?: string } = {},
+    cap = 99,
+    locale = 'ko-KR',
+    fallback = '0',
+  }: { cap?: number; locale?: string; fallback?: string } = {},
 ): string {
-  if (!Number.isFinite(count) || count < 0) return '0';
+  if (count == null || !Number.isFinite(count) || count < 0)
+    return fallback;
   if (count >= cap) return `${cap}+`;
   return count.toLocaleString(locale);
+}
+
+/**
+ * 숫자를 한글 약식으로 표기합니다. (1.2천, 1.2만, 100만 등)
+ *
+ * @param count - 표시할 숫자
+ * @param options - 옵션
+ * @param options.precision - 소수점 자릿수 (기본: 1)
+ * @param options.fallback - count가 invalid일 때 대체값 (기본: '0')
+ */
+export function formatKoreanCount(
+  count: number | null | undefined,
+  {
+    precision = 1,
+    fallback = '0',
+  }: { precision?: number; fallback?: string } = {},
+): string {
+  if (count == null || !Number.isFinite(count) || count < 0)
+    return fallback;
+
+  const units = [
+    { value: 100_000_000, symbol: '억', nextThreshold: Infinity }, // 억
+    { value: 10_000, symbol: '만', nextThreshold: 10000 }, // 만 (10000만 = 1억)
+    { value: 1_000, symbol: '천', nextThreshold: 10 }, // 천 (10천 = 1만)
+  ];
+
+  for (let i = 0; i < units.length; i++) {
+    const { value, symbol, nextThreshold } = units[i];
+
+    if (count >= value) {
+      const divided = count / value;
+      const formatted = divided.toFixed(precision);
+      const numericValue = parseFloat(formatted);
+
+      // 반올림 결과가 다음 단위 임계값에 도달하면 다음 단위로 처리
+      // 예: 9999 → 10.0천 → 1만, 99999999 → 10000.0만 → 1억
+      if (numericValue >= nextThreshold && i > 0) {
+        const nextUnit = units[i - 1];
+        const nextDivided = count / nextUnit.value;
+        const nextFormatted = nextDivided.toFixed(precision);
+        const nextCleaned = nextFormatted.replace(/\.0+$/, '');
+        const nextParts = nextCleaned.split('.');
+        nextParts[0] = parseInt(nextParts[0]).toLocaleString('ko-KR');
+        return `${nextParts.join('.')}${nextUnit.symbol}`;
+      }
+
+      // 소수점 제거 (1.0만 → 1만)
+      const cleaned = formatted.replace(/\.0+$/, '');
+      // 천 단위 콤마 추가 (1234.5만 → 1,234.5만)
+      const parts = cleaned.split('.');
+      parts[0] = parseInt(parts[0]).toLocaleString('ko-KR');
+      return `${parts.join('.')}${symbol}`;
+    }
+  }
+
+  return count.toLocaleString('ko-KR');
+}
+
+/**
+ * 숫자를 다양한 형식으로 표기하는 통합 함수
+ *
+ * @param count - 표시할 숫자
+ * @param options - 옵션
+ * @param options.type - 포맷 타입 (기본: 'capped')
+ * @param options.cap - capped 타입일 때 임계값 (기본: 99)
+ * @param options.precision - korean 타입일 때 소수점 자릿수 (기본: 1)
+ * @param options.locale - capped 타입일 때 로케일 (기본: 'ko-KR')
+ * @param options.fallback - count가 invalid일 때 대체값 (기본: '0')
+ *
+ * @example
+ * // Capped 형식 (기본)
+ * formatCount(50) // '50'
+ * formatCount(100) // '99+'
+ * formatCount(100, { cap: 999 }) // '100'
+ *
+ * // Korean 형식
+ * formatCount(1234, { type: 'korean' }) // '1.2천'
+ * formatCount(12345, { type: 'korean' }) // '1.2만'
+ * formatCount(1234567, { type: 'korean' }) // '123.5만'
+ * formatCount(100000000, { type: 'korean' }) // '1억'
+ *
+ * // 대체값
+ * formatCount(null, { fallback: '-' }) // '-'
+ * formatCount(undefined, { fallback: 'N/A' }) // 'N/A'
+ */
+export function formatCount(
+  count: number | null | undefined,
+  {
+    type = 'capped',
+    cap = 99,
+    precision = 1,
+    locale = 'ko-KR',
+    fallback = '0',
+  }: {
+    type?: FormatType;
+    cap?: number;
+    precision?: number;
+    locale?: string;
+    fallback?: string;
+  } = {},
+): string {
+  switch (type) {
+    case 'korean':
+      return formatKoreanCount(count, { precision, fallback });
+    case 'capped':
+    default:
+      return formatCappedCount(count, { cap, locale, fallback });
+  }
 }


### PR DESCRIPTION
# 📌 개요

자유게시판 리스트 페이지에 SSR 프리패치를 적용하여 초기 로딩 성능을 개선하고, 관련 UI/UX를 개선했습니다.

- 자유게시판 리스트 SSR 프리패치 구현
- formatCount 유틸리티 한글 단위 지원 (천, 만, 억)
- 가상 스크롤 gap 리사이징 이슈 해결
- 자유게시판 카드에 썸네일 이미지 추가
- SortHeader 스타일 개선

---

## 🗒 상세 설명

### 1. 자유게시판 리스트 SSR 프리패치 구현

서버 컴포넌트에서 자유게시판 리스트 첫 페이지를 프리패치하여 클라이언트 초기 렌더링 성능을 개선했습니다.

#### 핵심 기술 및 구현사항

- **React Query의 `prefetchInfiniteQuery`** 활용하여 서버에서 데이터 프리패치
- **HydrationBoundary**로 서버 데이터를 클라이언트에 전달
- **초기 상태 일치**: `category=undefined`, `sort='LATEST'`로 클라이언트 useState 초기값과 동일하게 설정
- **queryKey 일치**: 서버와 클라이언트의 쿼리 키를 정확히 일치시켜 캐시 히트 보장

#### 사용 예시

```tsx
// apps/web/src/app/main/community/freeboard/page.tsx
export default async function FreeboardPage() {
  const queryClient = new QueryClient();

  await queryClient.prefetchInfiniteQuery({
    queryKey: getGetFreeboardPostsByCursorQueryKey({
      category: undefined,
      sort: 'LATEST',
    }),
    queryFn: async ({ signal }) =>
      getFreeboardPostsByCursor(
        { category: undefined, sort: 'LATEST', size: 10 },
        signal,
      ),
    initialPageParam: undefined as string | undefined,
    getNextPageParam: (lastPage) => {
      return lastPage.hasNext ? lastPage.nextCursor : undefined;
    },
    pages: 1,
  });

  return (
    <HydrationBoundary state={dehydrate(queryClient)}>
      <ClientPage />
    </HydrationBoundary>
  );
}
```

**성능 개선 효과**:
- 초기 렌더링 시 네트워크 요청 제거 (서버에서 이미 fetch)
- 클라이언트는 캐시 히트로 즉시 데이터 표시

---

### 2. formatCount 유틸리티 한글 단위 지원

숫자 포맷팅 유틸리티에 한글 단위(천, 만, 억)를 추가하여 사용자 친화적인 숫자 표현을 제공합니다.

#### 핵심 기술 및 구현사항

- **`formatKoreanCount`** 함수 추가: 1.2천, 1.2만, 1.2억 형식 지원
- **반올림 임계값 처리**: 9999 → 1만 (10천 표시 방지)
- **null/undefined 처리**: fallback 옵션으로 대체값 제공
- **기존 호환성 유지**: `formatCappedCount` 함수는 기존 그대로 동작

#### 사용 예시

```tsx
// apps/web/src/utils/formatCount.ts
formatCount(1234, { type: 'korean' }) // '1.2천'
formatCount(12345, { type: 'korean' }) // '1.2만'
formatCount(9999, { type: 'korean' }) // '1만' (10천 X)
formatCount(1234567, { type: 'korean' }) // '123.5만'
formatCount(100000000, { type: 'korean' }) // '1억'
formatCount(null, { fallback: '-' }) // '-'

// 기본 capped 형식 (기존 호환)
formatCount(50) // '50'
formatCount(100) // '99+'
```

#### 개선 사항

- 천/만/억 단위 자동 변환
- 소수점 자동 제거 (1.0만 → 1만)
- 천 단위 콤마 추가 (1,234.5만)
- 10천 = 1만 중복 제거 로직

---

### 3. 가상 스크롤 Gap 리사이징 이슈 해결

창 크기 조절 또는 카드 클릭 시 아이템 간격(gap)이 중복 적용되는 문제를 해결했습니다.

#### 핵심 기술 및 구현사항

- **정확한 카드 평균 높이 계산**: `estimateSize`를 156px에서 139px로 수정
- **@tanstack/react-virtual** 측정 로직 최적화
- **ResizeObserver** 재측정 시 gap 중복 계산 방지

#### 해결한 문제

- ❌ **Before**: 카드 클릭 시 scale 변환 → ResizeObserver 감지 → 재측정 → gap 중복 적용
- ✅ **After**: 정확한 높이로 초기 측정 → 재측정 시에도 gap 정확히 유지

---

### 4. 자유게시판 카드에 썸네일 이미지 추가

게시글 카드에 썸네일 이미지를 표시하여 시각적 정보를 제공합니다.

#### 이미지

<img width="352" height="292" alt="image" src="https://github.com/user-attachments/assets/088c8385-680b-4b0f-b14b-d9fa11ce85f4" />


#### 사용 예시

```tsx
// apps/web/src/app/main/community/components/FreeboardCard.tsx
{post.thumbnailUrl && (
  <Image
    src={post.thumbnailUrl}
    alt="게시글 썸네일 이미지"
    width={55}
    height={55}
    className="w-[55px] h-[55px] object-cover rounded-md flex-shrink-0"
  />
)}
```

---

### 5. SortHeader 스타일 개선

정렬 헤더의 스타일을 개선하여 더 나은 UX를 제공합니다.

---

## 📸 스크린샷

UI 변경이 있을 경우, Before / After 스크린샷을 첨부해주세요.

### AS-IS

- 초기 로딩 시 네트워크 요청 발생 (느림)
- 숫자가 원시 형태로 표시 (1234567)
- Gap 리사이징 이슈 발생
- 썸네일 이미지 없음

<img width="296" height="634" alt="image" src="https://github.com/user-attachments/assets/eb45b9c0-6fc4-4da7-91db-2f37c165e7d4" />


### TO-BE

- 초기 로딩 시 즉시 데이터 표시 (빠름)
- 한글 단위로 친화적 표시 (123.5만)
- Gap 정확히 유지
- 썸네일 이미지 표시
- 게시글 수 헤더 색상 변경, Select 컴포넌트 border 스타일 제거
<img width="294" height="638" alt="image" src="https://github.com/user-attachments/assets/586db042-ce50-4526-88ac-5b95262dc42c" />

---

## 🔗 이슈

closes #80

---

## ✅ 체크리스트

- [x] 코드가 스타일 가이드를 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [x] 복잡/핵심 로직에 주석을 추가했습니다
- [x] 관심사 분리를 확인했습니다 (서버/클라이언트 컴포넌트 분리)
- [x] 잠재적 사이드이펙트를 점검했습니다 (queryKey 일치, 초기 상태 일치)
- [ ] Vercel Preview로 테스트를 완료했습니다

---

## 🧪 테스트 방법

다음 항목들을 검증했습니다:

- [x] SSR 프리패치 동작 확인 (네트워크 탭에서 초기 요청 없음)
- [x] 카테고리/정렬 변경 시 정상 동작
- [x] formatCount 한글 단위 정상 표시
- [x] 창 크기 조절 시 gap 유지 확인
- [x] 카드 클릭 시 gap 유지 확인
- [x] 썸네일 이미지 정상 표시

---

## 📝 추가 노트

### SSR 프리패치 동작 원리

1. **서버**: QueryClient 생성 → 데이터 프리패치 → dehydrate → HTML에 포함
2. **클라이언트**: HydrationBoundary가 데이터 주입 → useInfiniteQuery 캐시 히트 → 즉시 렌더링

### formatCount 설계 결정

- **Option 1 (특화 훅)**: `useFreeboardInfiniteQuery`, `useVoteboardInfiniteQuery` 등 개별 생성
- **Option 2 (제네릭 훅)**: `useCursorInfiniteQuery` 하나로 통합 ← **향후 고려 사항**

현재는 SSR 프리패치에 집중하고, 훅 추상화는 투표게시판 구현 시 적용 예정입니다.

### Gap 이슈 원인 분석

- `@tanstack/react-virtual`의 `gap` 옵션과 `measureElement`의 상호작용 이슈
- `estimateSize` 부정확 시 재측정 반복 → 누적 오차 발생
- 정확한 높이 계산으로 근본 해결

