### PR TITLE
Fix:  proxy 환경 변수 분리

### DIFF
--- a/apps/web/analyze.mjs
+++ b/apps/web/analyze.mjs
@@ -1,0 +1,17 @@
+import { spawn } from 'child_process';
+
+// Bundle Analyzer 활성화
+process.env.ANALYZE = 'true';
+
+console.log('📊 Starting Next.js build with bundle analyzer...\n');
+
+// next build 실행
+const build = spawn('next', ['build'], {
+  stdio: 'inherit',
+  shell: true,
+  env: { ...process.env },
+});
+
+build.on('close', (code) => {
+  process.exit(code);
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "NEXT_PUBLIC_ENABLE_PROXY=false next dev",
-    "dev:https": "NEXT_PUBLIC_ENABLE_PROXY=true node server.mjs",
+    "dev": "next dev",
+    "dev:https": "node server.mjs",
     "build": "next build",
-    "build:analyze": "ANALYZE=true next build",
+    "build:analyze": "node analyze.mjs",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",

--- a/apps/web/server.mjs
+++ b/apps/web/server.mjs
@@ -8,6 +8,9 @@ import { dirname, join } from 'path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+// HTTPS 모드에서는 프록시 활성화
+process.env.NEXT_PUBLIC_ENABLE_PROXY = 'true';
+
 const dev = process.env.NODE_ENV !== 'production';
 const hostname = 'localhost';
 const port = 3000;


### PR DESCRIPTION
# 📌 개요

이번 PR에서 바뀐 내용을 `한 줄` 혹은 `리스트` 로 요약해주세요.

- Proxy를 환경 변수로 분리해서 윈도우 호환성을 개선했습니다.

---

## 🗒 상세 설명

### 1. https모드와 http 모드를 사용할때 package.json에서 스크립트를 사용하지 않도록 했습니다.

### 2. build:analyze 를 개별 스크립트를 만들어서 윈도우 호환성을 개선했습니다.

## 📸 스크린샷

UI 변경이 있을 경우, Before / After 스크린샷을 첨부해주세요.

- package.json에서 스크립트 사용 안함
<img width="444" height="116" alt="image" src="https://github.com/user-attachments/assets/49ead3d0-e964-448f-876e-aaecaad92683" />

- 기존 명령어 정상 작동
<img width="497" height="423" alt="image" src="https://github.com/user-attachments/assets/d498c366-1af1-4838-8d15-3155015260ad" />

<img width="849" height="509" alt="image" src="https://github.com/user-attachments/assets/7f5d9515-3e74-421b-a052-e10cde66d993" />

---

## 🔗 이슈


closes #95

---

## ✅ 체크리스트

- [v] 코드가 스타일 가이드를 따릅니다

- [v] 자체 코드 리뷰를 완료했습니다

- [v] 복잡/핵심 로직에 주석을 추가했습니다

- [v] 관심사 분리를 확인했습니다

- [v] 잠재적 사이드이펙트를 점검했습니다

- [] Vercel Preview로 테스트를 완료했습니다

---

